### PR TITLE
fix: 3.4.68 修复牌堆中带有数字的情况下无法正常抽取；修复数字牌堆名被误解析为索引

### DIFF
--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.67",
-    "svn" : 1147,
+    "version" : "3.4.68",
+    "svn" : 1148,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.67'
-OlivaDiceCore_svn = 1147
+OlivaDiceCore_ver = '3.4.68'
+OlivaDiceCore_svn = 1148
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/drawCard.py
+++ b/OlivaDiceCore/drawCard.py
@@ -576,8 +576,10 @@ def getDrawDeck(key_str, bot_hash, count=1, valDict=None):
         dictStrCustom = OlivaDiceCore.msgCustom.dictStrCustomDict[bot_hash]
     if valDict is not None and 'dictTValue' in valDict:
         dictTValue = valDict['dictTValue']
-    key_str_resolved = resolveDrawDeckNameByIndex(key_str, bot_hash)
+    key_str_resolved = key_str
     if redirected_bot_hash in OlivaDiceCore.drawCardData.dictDeck:
+        if key_str not in OlivaDiceCore.drawCardData.dictDeck[redirected_bot_hash]:
+            key_str_resolved = resolveDrawDeckNameByIndex(key_str, bot_hash)
         if key_str_resolved in OlivaDiceCore.drawCardData.dictDeck[redirected_bot_hash]:
             if count >= 1 and count <= 10:
                 tmp_for_list = range(count)
@@ -641,6 +643,10 @@ def getDeckRecommend(key_str: str, bot_hash: str):
     return res
 
 
+def isVisibleDrawDeckName(deck_name):
+    return type(deck_name) is str and len(deck_name) > 0 and not deck_name.startswith('_')
+
+
 def getDrawDeckNameTable(bot_hash: str):
     res = []
 
@@ -651,7 +657,7 @@ def getDrawDeckNameTable(bot_hash: str):
         res = [
             deck_name_list_this
             for deck_name_list_this in deck_name_list
-            if (type(deck_name_list_this) is str and len(deck_name_list_this) > 0 and not deck_name_list_this.startswith('_'))
+            if isVisibleDrawDeckName(deck_name_list_this)
         ]
         # 按名称排序，保证数字索引映射稳定
         res.sort()

--- a/OlivaDiceCore/drawCard.py
+++ b/OlivaDiceCore/drawCard.py
@@ -576,8 +576,9 @@ def getDrawDeck(key_str, bot_hash, count=1, valDict=None):
         dictStrCustom = OlivaDiceCore.msgCustom.dictStrCustomDict[bot_hash]
     if valDict is not None and 'dictTValue' in valDict:
         dictTValue = valDict['dictTValue']
+    key_str_resolved = resolveDrawDeckNameByIndex(key_str, bot_hash)
     if redirected_bot_hash in OlivaDiceCore.drawCardData.dictDeck:
-        if key_str in OlivaDiceCore.drawCardData.dictDeck[redirected_bot_hash]:
+        if key_str_resolved in OlivaDiceCore.drawCardData.dictDeck[redirected_bot_hash]:
             if count >= 1 and count <= 10:
                 tmp_for_list = range(count)
                 tmp_card_list = []
@@ -590,7 +591,7 @@ def getDrawDeck(key_str, bot_hash, count=1, valDict=None):
                 ):
                     plugin_event = valDict['dictTValue']['vValDict']['vPluginEvent']
                 for tmp_for_list_this in tmp_for_list:
-                    tmp_draw_str = draw(key_str, bot_hash, mark_dict=None, plugin_event=plugin_event)
+                    tmp_draw_str = draw(key_str_resolved, bot_hash, mark_dict=None, plugin_event=plugin_event)
                     if tmp_draw_str is not None and type(tmp_draw_str) is str:
                         tmp_card_list.append(tmp_draw_str)
                 dictTValue['tDrawDeckResult'] = '\n'.join(tmp_card_list)
@@ -598,7 +599,7 @@ def getDrawDeck(key_str, bot_hash, count=1, valDict=None):
                 return tmp_reply_str
     tmp_recommend_list = []
     if OlivaDiceCore.console.getConsoleSwitchByHash('drawRecommendMode', bot_hash) == 1:
-        tmp_recommend_list = getDeckRecommend(key_str, bot_hash)
+        tmp_recommend_list = getDeckRecommend(key_str_resolved, bot_hash)
     if type(tmp_recommend_list) is list:
         if len(tmp_recommend_list) > 0:
             tmp_recommend_str = '\n'.join([
@@ -637,6 +638,37 @@ def getDeckRecommend(key_str: str, bot_hash: str):
                 if len(tmp_RecommendRank_list[count][1]) > 0 and tmp_RecommendRank_list[count][1][0] != '_':
                     res.append(tmp_RecommendRank_list[count][1])
         count += 1
+    return res
+
+
+def getDrawDeckNameTable(bot_hash: str):
+    res = []
+
+    redirected_bot_hash = OlivaDiceCore.userConfig.getRedirectedBotHash(bot_hash)
+
+    if redirected_bot_hash in OlivaDiceCore.drawCardData.dictDeck:
+        deck_name_list = list(OlivaDiceCore.drawCardData.dictDeck[redirected_bot_hash].keys())
+        res = [
+            deck_name_list_this
+            for deck_name_list_this in deck_name_list
+            if (type(deck_name_list_this) is str and len(deck_name_list_this) > 0 and not deck_name_list_this.startswith('_'))
+        ]
+        # 按名称排序，保证数字索引映射稳定
+        res.sort()
+
+    return res
+
+
+def resolveDrawDeckNameByIndex(key_str: str, bot_hash: str):
+    res = key_str
+
+    if type(key_str) is str and key_str.isdecimal():
+        key_index = int(key_str)
+        if key_index >= 1:
+            deck_name_table = getDrawDeckNameTable(bot_hash)
+            if key_index <= len(deck_name_table):
+                res = deck_name_table[key_index - 1]
+
     return res
 
 

--- a/OlivaDiceCore/msgReply.py
+++ b/OlivaDiceCore/msgReply.py
@@ -1591,40 +1591,49 @@ def unity_reply(plugin_event, Proc):
                 flag_hide = True
             tmp_reast_str = skipSpaceStart(tmp_reast_str)
             tmp_reast_str = tmp_reast_str.rstrip(' ')
-            # 先尝试匹配现有牌堆名，再从右边逐步提取数字（优先匹配更长的牌堆名）
+            # 先完整匹配牌堆名，再按固定牌堆名表拆分尾部数字，最后支持纯数字索引
             tmp_deck_name_candidate = tmp_reast_str
             tmp_card_count_str = None
-            redirected_bot_hash = OlivaDiceCore.userConfig.getRedirectedBotHash(plugin_event.bot_info.hash)
             if len(tmp_deck_name_candidate) > 0:
+                tmp_deck_name_candidate_norm = re.sub(r'\s+', r':', tmp_deck_name_candidate)
+                tmp_deck_name_candidate_norm = tmp_deck_name_candidate_norm.lstrip('_')
+                deck_name_table = OlivaDiceCore.drawCard.getDrawDeckNameTable(plugin_event.bot_info.hash)
+                deck_name_set = set(deck_name_table)
+
+                if tmp_deck_name_candidate_norm in deck_name_set:
+                    tmp_deck_name_candidate = tmp_deck_name_candidate_norm
+
                 # 计算右边连续数字的总长度
                 total_digit_count = 0
-                for i in range(len(tmp_deck_name_candidate) - 1, -1, -1):
-                    if tmp_deck_name_candidate[i].isdecimal():
+                for i in range(len(tmp_deck_name_candidate_norm) - 1, -1, -1):
+                    if tmp_deck_name_candidate_norm[i].isdecimal():
                         total_digit_count += 1
                     else:
                         break
-                # 如果有数字，从最少分离开始尝试（优先匹配更长的牌堆名）
-                if total_digit_count > 0:
+
+                # 仅当完整名未命中时，尝试拆分尾部数量
+                if tmp_deck_name_candidate_norm not in deck_name_set and total_digit_count > 0:
                     found_match = False
                     for digit_count in range(1, total_digit_count + 1):
-                        tmp_potential_deck_name = tmp_deck_name_candidate[:-digit_count]
-                        tmp_potential_count_str = tmp_deck_name_candidate[-digit_count:]
-                        tmp_check_deck_name = re.sub(r'\s+', r':', tmp_potential_deck_name)
-                        deck_exists = False
-                        if redirected_bot_hash in OlivaDiceCore.drawCardData.dictDeck:
-                            if tmp_check_deck_name in OlivaDiceCore.drawCardData.dictDeck[redirected_bot_hash]:
-                                deck_exists = True
-                        if not deck_exists and tmp_check_deck_name in OlivaDiceCore.drawCardData.dictDeckTemp:
-                            deck_exists = True
-                        if deck_exists:
+                        tmp_potential_deck_name = tmp_deck_name_candidate_norm[:-digit_count]
+                        tmp_potential_count_str = tmp_deck_name_candidate_norm[-digit_count:]
+                        if tmp_potential_deck_name in deck_name_set:
                             tmp_deck_name_candidate = tmp_potential_deck_name
                             tmp_card_count_str = tmp_potential_count_str
                             found_match = True
                             break
-                    # 如果都没匹配到，使用最后一次尝试的结果（分离所有数字）
-                    if not found_match and total_digit_count > 0:
-                        tmp_deck_name_candidate = tmp_reast_str[:-total_digit_count]
-                        tmp_card_count_str = tmp_reast_str[-total_digit_count:]
+
+                    if not found_match:
+                        # 纯数字参数可按牌堆名表索引（1-based）
+                        if tmp_deck_name_candidate_norm.isdecimal():
+                            tmp_deck_name_candidate = OlivaDiceCore.drawCard.resolveDrawDeckNameByIndex(
+                                tmp_deck_name_candidate_norm,
+                                plugin_event.bot_info.hash,
+                            )
+                        # 保留原行为：都未命中时，按“末尾连续数字”视作数量
+                        if tmp_deck_name_candidate == tmp_deck_name_candidate_norm:
+                            tmp_deck_name_candidate = tmp_deck_name_candidate_norm[:-total_digit_count]
+                            tmp_card_count_str = tmp_deck_name_candidate_norm[-total_digit_count:]
             if tmp_card_count_str == '':
                 tmp_card_count_str = None
             if tmp_card_count_str is not None:


### PR DESCRIPTION
## Summary by Sourcery

Improve draw deck name parsing and add numeric index resolution for decks while bumping core module version.

New Features:
- Allow selecting draw decks by numeric index derived from a sorted deck name table.

Bug Fixes:
- Fix failures when drawing from decks whose names contain trailing digits by refining deck name and count separation logic.

Enhancements:
- Normalize and validate deck names against a central deck name table before interpreting trailing digits as draw counts.