### PR TITLE
feat: 3.4.69 优化DND5E模板，新增'HP'和'HPMAX'条目

### DIFF
--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.68",
-    "svn" : 1148,
+    "version" : "3.4.69",
+    "svn" : 1149,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.68'
-OlivaDiceCore_svn = 1148
+OlivaDiceCore_ver = '3.4.69'
+OlivaDiceCore_svn = 1149
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/pcCardData.py
+++ b/OlivaDiceCore/pcCardData.py
@@ -2212,8 +2212,8 @@ dictPcCardTemplateDefaultTemp = {
                 '启蒙术',
             ],
         },
-        'skillConfig': {'skipEnhance': ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA']},
-        'init': {'STR': '4d6k3', 'DEX': '4d6k3', 'CON': '4d6k3', 'INT': '4d6k3', 'WIS': '4d6k3', 'CHA': '4d6k3'},
+        'skillConfig': {'skipEnhance': ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA', 'HP', 'HPMAX']},
+        'init': {'STR': '4d6k3', 'DEX': '4d6k3', 'CON': '4d6k3', 'INT': '4d6k3', 'WIS': '4d6k3', 'CHA': '4d6k3', 'HP': '10', 'HPMAX': '10'},
         'synonyms': {
             'STR': ['力量', 'STR', 'Strength'],
             'DEX': ['敏捷', 'DEX', 'Dexterity'],
@@ -2221,6 +2221,8 @@ dictPcCardTemplateDefaultTemp = {
             'INT': ['智力', 'INT', 'Intelligence'],
             'WIS': ['感知', 'WIS', 'Wisdom'],
             'CHA': ['魅力', 'CHA', 'Charisma'],
+            'HP': ['生命值', '体力', 'HP', 'HitPoints', '生命', '血量'],
+            'HPMAX': ['生命值上限', 'HPMAX', 'HitPointsMAX', '生命上限', '血量上限', '体力上限'],
             '运动': ['运动', 'Athletics'],
             '先攻': ['先攻', 'Initiative'],
             '速度': ['速度', 'Speed'],
@@ -2290,9 +2292,11 @@ dictPcCardTemplateDefaultTemp = {
             'INT': '智力',
             'WIS': '感知',
             'CHA': '魅力',
+            'HP': '生命',
+            'HPMAX': '生命上限',
         },
-        'snTitle': '{tName} AC{护甲等级} DC{法术豁免} PP{被动察觉}',
-        'defaultSkillValue': {'法术豁免': 8, '被动察觉': 10},
+        'snTitle': '{tName} hp{HP}/{HPMAX} AC{护甲等级} DC{法术豁免} PP{被动察觉}',
+        'defaultSkillValue': {'法术豁免': 8, '被动察觉': 10, 'HP': 10, 'HPMAX': 10},
         'checkRules': {
             'default': {
                 'checkList': ['greatSuccess', 'greatFail'],


### PR DESCRIPTION
## Summary by Sourcery

Introduce HP and HPMAX fields to the DND5E template and update core module metadata.

New Features:
- Add HP and HPMAX attributes to the DND5E character template, including initialization values, display title integration, and default values.

Enhancements:
- Extend DND5E template configuration to recognize additional HP-related synonyms and exclude HP fields from enhancement calculations.

Build:
- Bump core module version and SVN metadata to 3.4.69 / 1149.