### PR TITLE
fix: 3.4.70 适配QQ官方Bot成员及自身入群欢迎消息

### DIFF
--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.69",
-    "svn" : 1149,
+    "version" : "3.4.70",
+    "svn" : 1150,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.69'
-OlivaDiceCore_svn = 1149
+OlivaDiceCore_ver = '3.4.70'
+OlivaDiceCore_svn = 1150
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/msgEvent.py
+++ b/OlivaDiceCore/msgEvent.py
@@ -67,7 +67,7 @@ def getReRxEvent_group_message(src: OlivOS.API.Event, message: str):
         res.active = True
         res.data.user_id = src.data.user_id
         res.data.group_id = src.data.group_id
-        res.data.host_id = None
+        res.data.host_id = src.data.host_id
         res.data.message_id = '-1'
         res.data.font = None
         res.data.sender = {
@@ -76,7 +76,8 @@ def getReRxEvent_group_message(src: OlivOS.API.Event, message: str):
             'nickname': 'Nobody',
             'user_id': res.data.user_id,
         }
-        res.data.extend = {}
+        # 保留协议路由信息，使 QQ 官方 Bot 的成员/自身入群消息走 QQ 群主动发送接口。
+        res.data.extend = copy.deepcopy(getattr(src.data, 'extend', {}))
 
     getReRxEvent_message_format(res, target_message)
 


### PR DESCRIPTION
## Summary by Sourcery

Adapt group message handling to correctly route QQ official Bot member and self join welcome messages and bump the core module version.

Bug Fixes:
- Preserve host_id and protocol routing metadata in synthetic group message events so QQ official Bot join and welcome messages use the proper QQ group sending interface.

Chores:
- Update OlivaDiceCore module version metadata from 3.4.69 (svn 1149) to 3.4.70 (svn 1150).