### PR TITLE
feat: 3.4.71 .uinfo 新增 hag_id

### DIFF
--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.70",
-    "svn" : 1150,
+    "version" : "3.4.71",
+    "svn" : 1151,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.72",
-    "svn" : 1152,
+    "version" : "3.4.73",
+    "svn" : 1153,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.73",
-    "svn" : 1153,
+    "version" : "3.4.74",
+    "svn" : 1154,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/app.json
+++ b/OlivaDiceCore/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceCore",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的核心模块，提供了所有必须的骰子功能以及基础的管理支持，几乎所有的其它模块都依赖这个模块。",
-    "version" : "3.4.71",
-    "svn" : 1151,
+    "version" : "3.4.72",
+    "svn" : 1152,
     "compatible_svn" : 190,
     "priority" : 20000,
     "support" : [

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.71'
-OlivaDiceCore_svn = 1151
+OlivaDiceCore_ver = '3.4.72'
+OlivaDiceCore_svn = 1152
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.72'
-OlivaDiceCore_svn = 1152
+OlivaDiceCore_ver = '3.4.73'
+OlivaDiceCore_svn = 1153
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.73'
-OlivaDiceCore_svn = 1153
+OlivaDiceCore_ver = '3.4.74'
+OlivaDiceCore_svn = 1154
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/data.py
+++ b/OlivaDiceCore/data.py
@@ -22,8 +22,8 @@ import uuid
 import OlivOS
 
 OlivaDiceCore_name = 'OlivaDice核心模块'
-OlivaDiceCore_ver = '3.4.70'
-OlivaDiceCore_svn = 1150
+OlivaDiceCore_ver = '3.4.71'
+OlivaDiceCore_svn = 1151
 OlivaDiceCore_ver_short = '%s(%s)' % (str(OlivaDiceCore_ver), str(OlivaDiceCore_svn))
 
 exce_path = os.getcwd()

--- a/OlivaDiceCore/helpDocData.py
+++ b/OlivaDiceCore/helpDocData.py
@@ -430,6 +430,7 @@ https://github.com/OlivOS-Team/onedice
 若需要获取新成员名称，请在欢迎词中添加[{tNewMemberName}]
 如[.welcome {tAtNewMember}，欢迎[{tNewMemberName}]加入本群！]""",
     'team': """.team (小队) [@成员1][@成员2]…… 创建/更新小队
+.team (小队) (add) me (小队) 将自己加入小队，无小队时创建小队
 .team (小队) show (小队) 展示小队成员
 .team list 列出所有小队
 .team (小队) set (小队) 设置活跃小队

--- a/OlivaDiceCore/msgReply.py
+++ b/OlivaDiceCore/msgReply.py
@@ -7236,7 +7236,93 @@ def replyMsg(plugin_event, message, at_user=False):
         at_user_msg = at_para.get_string_by_key('CQ')
         return OlivaDiceCore.msgReply.pluginReply(plugin_event, f'{at_user_msg} ' + str(message))
     else:
+        # qqGuildv2 平台在最后判断是否走 markdown 通道；其余平台走普通文本回复
+        if _isQQGuildv2MarkdownAble(plugin_event):
+            msg_str = str(message)
+            # CQ 图片/表情时 markdown 无法渲染，回退文本回复
+            if '[CQ:image' in msg_str or '[CQ:face' in msg_str:
+                return OlivaDiceCore.msgReply.pluginReply(plugin_event, msg_str)
+            return _replyMsgMarkdownQQGuildv2(plugin_event, msg_str)
         return OlivaDiceCore.msgReply.pluginReply(plugin_event, str(message))
+
+
+def _buildMarkdownFromCQString(message):
+    """将 CQ 格式的消息文本转译为 qqGuildv2 markdown 内容
+    使用 Message_templet('old_string', ...) 解析 CQ 段并逐 Para 转译；
+    at 通过 OlivOS markdown_tag 内置接口输出，纯文本取 data['text']，其余 Para 兜底用 CQ 码输出"""
+    md_content = ''
+    msg_para = OlivOS.messageAPI.Message_templet('old_string', str(message))
+    for para in msg_para.data:
+        if isinstance(para, OlivOS.messageAPI.PARA.at):
+            at_id = str(para.data.get('id', ''))
+            if at_id == 'all':
+                md_content += '<qqbot-at-everyone />'
+            else:
+                md_content += OlivOS.qqGuildv2SDK.markdown_tag.at_user(at_id)
+        elif isinstance(para, OlivOS.messageAPI.PARA.text):
+            md_content += para.data.get('text', '')
+        else:
+            # 其他 Para（如 reply、json 等）兜底，用 CQ 码输出
+            md_content += para.get_string_by_key('CQ')
+    return md_content
+
+
+def _isQQGuildv2MarkdownAble(plugin_event):
+    """检测当前事件是否来自 qqGuildv2 平台且具备 markdown 消息发送能力"""
+    res = False
+    try:
+        if (
+            plugin_event.platform['sdk'] == 'qqGuildv2_link'
+            and plugin_event.indeAPI is not None
+            and plugin_event.indeAPI.hasAPI('create_markdown_message')
+        ):
+            res = True
+    except Exception:
+        res = False
+    return res
+
+
+def _replyMsgMarkdownQQGuildv2(plugin_event, message):
+    """replyMsg 的 qqGuildv2 markdown 发送收口
+
+    完成敏感词检测后通过 Message_templet 解析 CQ 段并构建 markdown 内容，
+    发送失败时回退 pluginReply（此时保留原始消息，由 SDK 路径处理）
+    """
+    # 敏感词检测，与 pluginReply 一致
+    message = OlivaDiceCore.censorAPI.doCensorReplaceOlivOSSafe(
+        botHash=plugin_event.bot_info.hash, msg=str(message)
+    )
+    res_data = None
+    try:
+        extend_data = getattr(plugin_event.data, 'extend', {})
+        chat_type = 'qq_group' if extend_data.get('flag_from_qq', False) else 'guild_channel'
+        md_content = _buildMarkdownFromCQString(message)
+        res_data = plugin_event.indeAPI.create_markdown_message(
+            chat_type=chat_type,
+            chat_id=plugin_event.data.group_id,
+            markdown={'content': md_content},
+            msg_id=extend_data.get('reply_msg_id'),
+        )
+    except Exception:
+        res_data = None
+    if res_data is None or not res_data.get('active', False):
+        return OlivaDiceCore.msgReply.pluginReply(plugin_event, message)
+    return res_data
+
+
+def isQQGuildv2MarkdownAble(plugin_event):
+    """检测当前事件是否来自 qqGuildv2 平台且具备 markdown 消息发送能力"""
+    res = False
+    try:
+        if (
+            plugin_event.platform['sdk'] == 'qqGuildv2_link'
+            and plugin_event.indeAPI is not None
+            and plugin_event.indeAPI.hasAPI('create_markdown_message')
+        ):
+            res = True
+    except Exception:
+        res = False
+    return res
 
 
 def sendMsgByEvent(plugin_event, message, target_id, target_type, host_id=None):

--- a/OlivaDiceCore/msgReply.py
+++ b/OlivaDiceCore/msgReply.py
@@ -2062,10 +2062,12 @@ def unity_reply(plugin_event, Proc):
                         'tUserConfig': '',
                         'tTrustLevel': 'N/A',
                         'tTrustRank': 'N/A',
+                        'tHagId': '',
                     }
                     tmp_reply_str_temp = (
                         '[{tUserName}] - ({tUserId})'
                         '\n记录哈希: {tUserHash}'
+                        '{tHagId}'
                         '\n平台: {tUserPlatform}'
                         '\n最后触发: {tUserLastHit}'
                         '\n信任等级/评分: {tTrustLevel} / {tTrustRank}{tUserConfig}'
@@ -2078,8 +2080,10 @@ def unity_reply(plugin_event, Proc):
                         tmp_dictTValue['tUserName'] = tmp_userName
                     elif flag_userInfoType == 'group':
                         tmp_dictTValue['tUserName'] = '群'
+                        tmp_dictTValue['tHagId'] = '\n群号/频道号(hag_id): %s' % tmp_userId
                     elif flag_userInfoType == 'host':
                         tmp_dictTValue['tUserName'] = '频道'
+                        tmp_dictTValue['tHagId'] = '\n群号/频道号(hag_id): %s' % tmp_userId
                     tmp_dictTValue['tTrustLevel'] = str(
                         OlivaDiceCore.userConfig.getUserConfigByKeyWithHash(
                             userHash=tmp_userHash, userConfigKey='trustLevel', botHash=plugin_event.bot_info.hash

--- a/OlivaDiceCore/msgReply.py
+++ b/OlivaDiceCore/msgReply.py
@@ -7234,16 +7234,17 @@ def replyMsg(plugin_event, message, at_user=False):
     if at_user:
         at_para = OlivOS.messageAPI.PARA.at(str(user_id))
         at_user_msg = at_para.get_string_by_key('CQ')
-        return OlivaDiceCore.msgReply.pluginReply(plugin_event, f'{at_user_msg} ' + str(message))
+        message = f'{at_user_msg} ' + str(message)
     else:
-        # qqGuildv2 平台在最后判断是否走 markdown 通道；其余平台走普通文本回复
-        if _isQQGuildv2MarkdownAble(plugin_event):
-            return _replyMsgMarkdownQQGuildv2(plugin_event, str(message))
-        return OlivaDiceCore.msgReply.pluginReply(plugin_event, str(message))
+        message = str(message)
+    # QQ Guild v2 仅在消息实际包含 at 段时使用 Markdown，其余消息保持普通文本通道。
+    if _isQQGuildv2MarkdownAble(plugin_event, message):
+        return _replyMsgMarkdownQQGuildv2(plugin_event, message)
+    return OlivaDiceCore.msgReply.pluginReply(plugin_event, message)
 
 
-def _isQQGuildv2MarkdownAble(plugin_event):
-    """检测当前事件是否来自 qqGuildv2 平台且具备 markdown 消息发送能力"""
+def _isQQGuildv2MarkdownAble(plugin_event, message):
+    """检测消息是否必须通过 QQ Guild v2 Markdown 通道发送 at。"""
     res = False
     try:
         if (
@@ -7251,7 +7252,14 @@ def _isQQGuildv2MarkdownAble(plugin_event):
             and plugin_event.indeAPI is not None
             and plugin_event.indeAPI.hasAPI('create_markdown_message')
         ):
-            res = True
+            if isinstance(message, OlivOS.messageAPI.Message_templet):
+                message_obj = message
+            else:
+                message_obj = OlivOS.messageAPI.Message_templet('old_string', str(message))
+            res = any(
+                isinstance(para_this, OlivOS.messageAPI.PARA.at)
+                for para_this in message_obj.data
+            )
     except Exception:
         res = False
     return res
@@ -7270,6 +7278,7 @@ def _replyMsgMarkdownQQGuildv2(plugin_event, message):
     # 用 Message_templet 解析 Para，拆分为 md 部分和文本部分
     md_content = ''
     plain_parts = []
+    quote_msg_id = None
     msg_para = OlivOS.messageAPI.Message_templet('old_string', str(message))
     for para in msg_para.data:
         if isinstance(para, OlivOS.messageAPI.PARA.at):
@@ -7280,20 +7289,36 @@ def _replyMsgMarkdownQQGuildv2(plugin_event, message):
                 md_content += OlivOS.qqGuildv2SDK.markdown_tag.at_user(at_id)
         elif isinstance(para, OlivOS.messageAPI.PARA.text):
             md_content += para.data.get('text', '')
+        elif isinstance(para, OlivOS.messageAPI.PARA.reply):
+            if quote_msg_id is None:
+                quote_id = para.data.get('id', None)
+                if quote_id is not None and str(quote_id) != '':
+                    quote_msg_id = str(quote_id)
         else:
-            # 图片、表情、reply 等走文本通道
+            # 图片、表情等媒体继续走 OlivOS 普通消息通道
             plain_parts.append(para)
     # 发送 markdown 部分（有内容时）
     md_ok = True
     if md_content != '':
         try:
             extend_data = getattr(plugin_event.data, 'extend', {})
-            chat_type = 'qq_group' if extend_data.get('flag_from_qq', False) else 'guild_channel'
+            flag_from_qq = extend_data.get('flag_from_qq', False)
+            flag_from_direct = extend_data.get('flag_from_direct', False)
+            if flag_from_qq:
+                chat_type = 'qq_private' if flag_from_direct else 'qq_group'
+                chat_id = plugin_event.data.user_id if flag_from_direct else plugin_event.data.group_id
+            else:
+                chat_type = 'guild_private' if flag_from_direct else 'guild_channel'
+                if flag_from_direct:
+                    chat_id = extend_data.get('host_group_id', None)
+                else:
+                    chat_id = plugin_event.data.group_id
             res_data = plugin_event.indeAPI.create_markdown_message(
                 chat_type=chat_type,
-                chat_id=plugin_event.data.group_id,
+                chat_id=chat_id,
                 markdown={'content': md_content},
                 msg_id=extend_data.get('reply_msg_id'),
+                quote_msg_id=quote_msg_id,
             )
             if res_data is None or not res_data.get('active', False):
                 md_ok = False
@@ -7303,9 +7328,11 @@ def _replyMsgMarkdownQQGuildv2(plugin_event, message):
     if not md_ok:
         return OlivaDiceCore.msgReply.pluginReply(plugin_event, message)
     # 发送媒体部分（图片/表情等）
+    if md_content == '' and quote_msg_id is not None:
+        plain_parts.insert(0, OlivOS.messageAPI.PARA.reply(id=quote_msg_id))
     if plain_parts:
         plain_msg = OlivOS.messageAPI.Message_templet('olivos_para', plain_parts)
-        return OlivaDiceCore.msgReply.pluginReply(plugin_event, plain_msg)
+        return OlivaDiceCore.msgReply.pluginReply(plugin_event, plain_msg.get('old_string'))
     return None
 
 

--- a/OlivaDiceCore/msgReply.py
+++ b/OlivaDiceCore/msgReply.py
@@ -7238,33 +7238,8 @@ def replyMsg(plugin_event, message, at_user=False):
     else:
         # qqGuildv2 平台在最后判断是否走 markdown 通道；其余平台走普通文本回复
         if _isQQGuildv2MarkdownAble(plugin_event):
-            msg_str = str(message)
-            # CQ 图片/表情时 markdown 无法渲染，回退文本回复
-            if '[CQ:image' in msg_str or '[CQ:face' in msg_str:
-                return OlivaDiceCore.msgReply.pluginReply(plugin_event, msg_str)
-            return _replyMsgMarkdownQQGuildv2(plugin_event, msg_str)
+            return _replyMsgMarkdownQQGuildv2(plugin_event, str(message))
         return OlivaDiceCore.msgReply.pluginReply(plugin_event, str(message))
-
-
-def _buildMarkdownFromCQString(message):
-    """将 CQ 格式的消息文本转译为 qqGuildv2 markdown 内容
-    使用 Message_templet('old_string', ...) 解析 CQ 段并逐 Para 转译；
-    at 通过 OlivOS markdown_tag 内置接口输出，纯文本取 data['text']，其余 Para 兜底用 CQ 码输出"""
-    md_content = ''
-    msg_para = OlivOS.messageAPI.Message_templet('old_string', str(message))
-    for para in msg_para.data:
-        if isinstance(para, OlivOS.messageAPI.PARA.at):
-            at_id = str(para.data.get('id', ''))
-            if at_id == 'all':
-                md_content += '<qqbot-at-everyone />'
-            else:
-                md_content += OlivOS.qqGuildv2SDK.markdown_tag.at_user(at_id)
-        elif isinstance(para, OlivOS.messageAPI.PARA.text):
-            md_content += para.data.get('text', '')
-        else:
-            # 其他 Para（如 reply、json 等）兜底，用 CQ 码输出
-            md_content += para.get_string_by_key('CQ')
-    return md_content
 
 
 def _isQQGuildv2MarkdownAble(plugin_event):
@@ -7285,44 +7260,53 @@ def _isQQGuildv2MarkdownAble(plugin_event):
 def _replyMsgMarkdownQQGuildv2(plugin_event, message):
     """replyMsg 的 qqGuildv2 markdown 发送收口
 
-    完成敏感词检测后通过 Message_templet 解析 CQ 段并构建 markdown 内容，
-    发送失败时回退 pluginReply（此时保留原始消息，由 SDK 路径处理）
+    将消息拆分为文本/at（走 markdown 通道，确保 at 正确）和图片等媒体（走文本回复），
+    敏感词检测后分别发送。markdown 部分失败时回退全部走 pluginReply。
     """
     # 敏感词检测，与 pluginReply 一致
     message = OlivaDiceCore.censorAPI.doCensorReplaceOlivOSSafe(
         botHash=plugin_event.bot_info.hash, msg=str(message)
     )
-    res_data = None
-    try:
-        extend_data = getattr(plugin_event.data, 'extend', {})
-        chat_type = 'qq_group' if extend_data.get('flag_from_qq', False) else 'guild_channel'
-        md_content = _buildMarkdownFromCQString(message)
-        res_data = plugin_event.indeAPI.create_markdown_message(
-            chat_type=chat_type,
-            chat_id=plugin_event.data.group_id,
-            markdown={'content': md_content},
-            msg_id=extend_data.get('reply_msg_id'),
-        )
-    except Exception:
-        res_data = None
-    if res_data is None or not res_data.get('active', False):
+    # 用 Message_templet 解析 Para，拆分为 md 部分和文本部分
+    md_content = ''
+    plain_parts = []
+    msg_para = OlivOS.messageAPI.Message_templet('old_string', str(message))
+    for para in msg_para.data:
+        if isinstance(para, OlivOS.messageAPI.PARA.at):
+            at_id = str(para.data.get('id', ''))
+            if at_id == 'all':
+                md_content += '<qqbot-at-everyone />'
+            else:
+                md_content += OlivOS.qqGuildv2SDK.markdown_tag.at_user(at_id)
+        elif isinstance(para, OlivOS.messageAPI.PARA.text):
+            md_content += para.data.get('text', '')
+        else:
+            # 图片、表情、reply 等走文本通道
+            plain_parts.append(para)
+    # 发送 markdown 部分（有内容时）
+    md_ok = True
+    if md_content != '':
+        try:
+            extend_data = getattr(plugin_event.data, 'extend', {})
+            chat_type = 'qq_group' if extend_data.get('flag_from_qq', False) else 'guild_channel'
+            res_data = plugin_event.indeAPI.create_markdown_message(
+                chat_type=chat_type,
+                chat_id=plugin_event.data.group_id,
+                markdown={'content': md_content},
+                msg_id=extend_data.get('reply_msg_id'),
+            )
+            if res_data is None or not res_data.get('active', False):
+                md_ok = False
+        except Exception:
+            md_ok = False
+    # markdown 失败时全部回退
+    if not md_ok:
         return OlivaDiceCore.msgReply.pluginReply(plugin_event, message)
-    return res_data
-
-
-def isQQGuildv2MarkdownAble(plugin_event):
-    """检测当前事件是否来自 qqGuildv2 平台且具备 markdown 消息发送能力"""
-    res = False
-    try:
-        if (
-            plugin_event.platform['sdk'] == 'qqGuildv2_link'
-            and plugin_event.indeAPI is not None
-            and plugin_event.indeAPI.hasAPI('create_markdown_message')
-        ):
-            res = True
-    except Exception:
-        res = False
-    return res
+    # 发送媒体部分（图片/表情等）
+    if plain_parts:
+        plain_msg = OlivOS.messageAPI.Message_templet('olivos_para', plain_parts)
+        return OlivaDiceCore.msgReply.pluginReply(plugin_event, plain_msg)
+    return None
 
 
 def sendMsgByEvent(plugin_event, message, target_id, target_type, host_id=None):

--- a/OlivaDiceCore/msgReplyModel.py
+++ b/OlivaDiceCore/msgReplyModel.py
@@ -1829,7 +1829,129 @@ def replyTEAM_command(plugin_event, Proc, valDict):
     elif OlivaDiceCore.msgReply.isMatchWordStart(tmp_reast_str, 'help', fullMatch=True):
         OlivaDiceCore.msgReply.replyMsgLazyHelpByEvent(plugin_event, 'team')
     else:
-        team_create(plugin_event, tmp_reast_str, tmp_hagID, dictTValue, dictStrCustom, team_name)
+        # 主动入队语法: .team (小队名) (add) me (小队名)，未命中时回退为小队创建
+        [flag_team_join_self, team_name] = parse_team_join_self(tmp_reast_str, team_name)
+        if flag_team_join_self:
+            team_add_me(plugin_event, tmp_reast_str, tmp_hagID, dictTValue, dictStrCustom, team_name)
+        else:
+            # 兼容 .team add [@成员……] 形式——剥离可选的 add 前缀后交给 team_create
+            tmp_create_str = tmp_reast_str
+            if OlivaDiceCore.msgReply.isMatchWordStart(tmp_create_str, 'add'):
+                tmp_create_str = OlivaDiceCore.msgReply.getMatchWordStartRight(tmp_create_str, 'add')
+                tmp_create_str = OlivaDiceCore.msgReply.skipSpaceStart(tmp_create_str)
+            team_create(plugin_event, tmp_create_str, tmp_hagID, dictTValue, dictStrCustom, team_name)
+
+
+def parse_team_join_self(tmp_reast_str, team_name):
+    """
+    解析 .team 主动入队语法: (add) me (小队名)
+    小队名可由 replyTEAM_command 前置解析（已有小队），或放在 me 之后（支持新小队名）
+    返回 [是否命中主动入队语法, 解析后的小队名(未指定时为None)]
+    """
+    res_flag = False
+    res_team_name = team_name
+    tmp_str = tmp_reast_str
+    # 去掉可选的 add 前缀
+    if OlivaDiceCore.msgReply.isMatchWordStart(tmp_str, 'add'):
+        tmp_str = OlivaDiceCore.msgReply.getMatchWordStartRight(tmp_str, 'add')
+        tmp_str = OlivaDiceCore.msgReply.skipSpaceStart(tmp_str)
+    # 开头匹配 me（前缀匹配，与项目内其他子指令的 isMatchWordStart 用法一致）
+    if OlivaDiceCore.msgReply.isMatchWordStart(tmp_str, 'me'):
+        res_flag = True
+        tmp_str = OlivaDiceCore.msgReply.getMatchWordStartRight(tmp_str, 'me')
+        tmp_str = OlivaDiceCore.msgReply.skipSpaceStart(tmp_str)
+        if res_team_name is None and tmp_str != '':
+            res_team_name = tmp_str
+    # 后缀形式: .team 新小队名 me / .team 新小队名 add me
+    # me 在结尾，使用字符串处理（与 team_at/team_set 等子指令的 "动作 小队名" 风格一致）
+    if not res_flag:
+        tmp_str_strip = tmp_str.strip()
+        if tmp_str_strip.lower() == 'me' or tmp_str_strip.lower().endswith(' me'):
+            res_flag = True
+            prefix = tmp_str_strip[:-3].strip() if tmp_str_strip.lower().endswith(' me') else ''
+            if prefix != '':
+                # 去掉末尾可能残留的 add（支持 .team 新小队名 add me 形式）
+                if prefix.lower().endswith(' add') or prefix.lower() == 'add':
+                    prefix = prefix[: -len('add')].strip()
+                if res_team_name is None:
+                    res_team_name = prefix
+    return [res_flag, res_team_name]
+
+
+def team_add_me(plugin_event, tmp_reast_str, tmp_hagID, dictTValue, dictStrCustom, team_name):
+    # 用户主动加入小队: .team (小队名) (add) me (小队名)
+    # 成员 id 与 at 解析结果保持一致，统一存为字符串
+    tmp_member_id = str(plugin_event.data.user_id)
+    team_config = OlivaDiceCore.userConfig.getUserConfigByKey(
+        userId=tmp_hagID,
+        userType='group',
+        platform=plugin_event.platform['platform'],
+        userConfigKey='teamConfig',
+        botHash=plugin_event.bot_info.hash,
+        default={},
+    )
+    active_team = OlivaDiceCore.userConfig.getUserConfigByKey(
+        userId=tmp_hagID,
+        userType='group',
+        platform=plugin_event.platform['platform'],
+        userConfigKey='activeTeam',
+        botHash=plugin_event.bot_info.hash,
+    )
+    # 未指定小队时加入当前活跃小队；没有活跃小队时创建默认小队
+    if team_name is None or team_name == '':
+        if active_team is None:
+            team_name = 'default'
+        else:
+            team_name = active_team
+    # 小队不存在时创建小队并设为活跃小队，存在时仅更新成员
+    if team_name not in team_config:
+        team_config[team_name] = {'members': [tmp_member_id], 'created': int(time.time())}
+        OlivaDiceCore.userConfig.setUserConfigByKey(
+            userConfigKey='activeTeam',
+            userConfigValue=team_name,
+            botHash=plugin_event.bot_info.hash,
+            userId=tmp_hagID,
+            userType='group',
+            platform=plugin_event.platform['platform'],
+        )
+    else:
+        existing_members = set(team_config[team_name]['members'])
+        existing_members.add(tmp_member_id)
+        team_config[team_name]['members'] = list(existing_members)
+    OlivaDiceCore.userConfig.setUserConfigByKey(
+        userConfigKey='teamConfig',
+        userConfigValue=team_config,
+        botHash=plugin_event.bot_info.hash,
+        userId=tmp_hagID,
+        userType='group',
+        platform=plugin_event.platform['platform'],
+    )
+    OlivaDiceCore.userConfig.writeUserConfigByUserHash(
+        userHash=OlivaDiceCore.userConfig.getUserHash(
+            userId=tmp_hagID, userType='group', platform=plugin_event.platform['platform']
+        )
+    )
+    # 复用 team_create 的回复词与成员列表格式
+    members = team_config[team_name]['members']
+    member_info = []
+    index = 1
+    for member_id in members:
+        # 获取用户名称
+        user_name = get_user_name(plugin_event, member_id)
+        # 获取当前人物卡
+        pc_hash = OlivaDiceCore.pcCard.getPcHash(member_id, plugin_event.platform['platform'])
+        pc_name = OlivaDiceCore.pcCard.pcCardDataGetSelectionKey(pc_hash, tmp_hagID)
+        member_display = format_team_member_display(
+            user_name, pc_name, dictStrCustom, 'strTeamMemberFormatWithIndex', tIndex=f'{index}'
+        )
+        member_info.append(member_display)
+        index += 1
+    dictTValue['tTeamName'] = team_name
+    dictTValue['tMemberCount'] = str(len(members))
+    dictTValue['tMembers'] = '\n'.join(member_info)
+    OlivaDiceCore.msgReply.replyMsg(
+        plugin_event, OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strTeamCreated'], dictTValue)
+    )
 
 
 def team_create(plugin_event, tmp_reast_str, tmp_hagID, dictTValue, dictStrCustom, team_name):
@@ -2374,7 +2496,7 @@ def team_at(plugin_event, tmp_reast_str, tmp_hagID, dictTValue, dictStrCustom, t
         )
         return
 
-    # at实现
+    # at 实现：使用标准 CQ 码 via replyMsg，replyMsg 内部会根据平台选择发送通路
     at_members_str = ''
     for member_id in members:
         at_para = OlivOS.messageAPI.PARA.at(str(member_id))


### PR DESCRIPTION
## Summary by Sourcery

Add hag_id display to user info responses for groups and channels and bump OlivaDiceCore module version to 3.4.71.

New Features:
- Include hag_id (group/channel identifier) in .uinfo-style user information output for group and host contexts.

Enhancements:
- Update OlivaDiceCore core module metadata and internal version constants to 3.4.71/1151.